### PR TITLE
Revert prematurely merged "Add swift-async-dns-resolver" PR

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,11 +4,6 @@
   "keywords": ["server", "sswg"],
   "packages": [
     {
-      "url": "https://github.com/apple/swift-async-dns-resolver",
-      "excludedProducts": [],
-      "excludedTargets": [],      
-    },
-    {
       "url": "https://github.com/apple/swift-cassandra-client",
       "excludedProducts": [],
       "excludedTargets": [],      
@@ -44,12 +39,12 @@
       "excludedTargets": [],
     },
     {
-      "url": "https://github.com/apple/swift-service-context",
+      "url": "https://github.com/apple/swift-statsd-client",
       "excludedProducts": [],
       "excludedTargets": [],
     },
     {
-      "url": "https://github.com/apple/swift-statsd-client",
+      "url": "https://github.com/apple/swift-service-context",
       "excludedProducts": [],
       "excludedTargets": [],
     },


### PR DESCRIPTION
The list contains "libraries and tools incubated by the SSWG." so we need to pitch the https://github.com/apple/swift-async-dns-resolver before we can add it here AFAICS.

Sorry for the too quick merge @yim-lee  -- let's get it reviewed and added soon though! 

Reverts swift-server/sswg-collection#7